### PR TITLE
feat(web): label and priority update on table row action

### DIFF
--- a/apps/web/src/app/dashboard/tasks/_data/index.ts
+++ b/apps/web/src/app/dashboard/tasks/_data/index.ts
@@ -29,16 +29,19 @@ export const priorities = [
     label: "Low",
     value: "low",
     icon: ArrowDownIcon,
+    color: "text-cyan-300",
   },
   {
     label: "Medium",
     value: "medium",
     icon: ArrowRightIcon,
+    color: "text-amber-500",
   },
   {
     label: "High",
     value: "high",
     icon: ArrowUpIcon,
+    color: "text-red-500",
   },
 ];
 
@@ -47,25 +50,30 @@ export const statuses = [
     value: "backlog",
     label: "Backlog",
     icon: QuestionMarkCircledIcon,
+    color: "text-muted-foreground",
   },
   {
     value: "todo",
     label: "Todo",
     icon: CircleIcon,
+    color: "text-purple-400",
   },
   {
     value: "in progress",
     label: "In Progress",
     icon: StopwatchIcon,
+    color: "text-orange-300",
   },
   {
     value: "done",
     label: "Done",
     icon: CheckCircledIcon,
+    color: "text-teal-500",
   },
   {
     value: "cancelled",
     label: "Cancelled",
     icon: CrossCircledIcon,
+    color: "text-red-400",
   },
 ];

--- a/apps/web/src/app/dashboard/tasks/components/Column.tsx
+++ b/apps/web/src/app/dashboard/tasks/components/Column.tsx
@@ -90,7 +90,7 @@ export const columns: ColumnDef<Task>[] = [
       return (
         <div className="flex w-[100px] items-center">
           {status.icon && (
-            <status.icon className="mr-2 h-4 w-4 text-muted-foreground" />
+            <status.icon className={cn("mr-2 h-4 w-4", status.color)} />
           )}
           <span>{status.label}</span>
         </div>
@@ -117,7 +117,7 @@ export const columns: ColumnDef<Task>[] = [
       return (
         <div className="flex items-center">
           {priority.icon && (
-            <priority.icon className="mr-2 h-4 w-4 text-muted-foreground" />
+            <priority.icon className={cn("mr-2 h-4 w-4", priority.color)} />
           )}
           <span>{priority.label}</span>
         </div>

--- a/apps/web/src/server/router/tasks/delete.ts
+++ b/apps/web/src/server/router/tasks/delete.ts
@@ -28,7 +28,7 @@ export const DeleteTasksRouter = createTRPCRouter({
   multiple: protectedProcedure
     .input(
       z.object({
-        ids: z.array(z.string().cuid2()).min(2),
+        ids: z.array(z.string().cuid2()).min(1),
       }),
     )
     .mutation(async ({ ctx, input }) => {

--- a/apps/web/src/server/router/tasks/update.ts
+++ b/apps/web/src/server/router/tasks/update.ts
@@ -42,7 +42,7 @@ export const UpdateTasksRouter = createTRPCRouter({
   multiple: protectedProcedure
     .input(
       z.object({
-        ids: z.array(z.string().cuid2()).min(2),
+        ids: z.array(z.string().cuid2()).min(1),
         params: updateBatchParams,
       }),
     )


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces color coding for task priorities and statuses, and allows for updating of task labels and priorities directly from the task actions dropdown. It also modifies the minimum requirement for batch task updates and deletions from 2 to 1.
> 
> ## What changed
> - Added color coding for task priorities and statuses in `apps/web/src/app/dashboard/tasks/_data/index.ts`
> - Updated `Column.tsx` to reflect the color changes in task priorities and statuses
> - Updated `TableRowActions.tsx` to allow for updating of task labels and priorities directly from the task actions dropdown
> - Modified the minimum requirement for batch task updates and deletions from 2 to 1 in `delete.ts` and `update.ts`
> 
> ## How to test
> 1. Pull the changes from this branch into your local environment
> 2. Run the application
> 3. Navigate to the tasks dashboard
> 4. Check that tasks are color-coded according to their priorities and statuses
> 5. Try updating a task's label and priority from the task actions dropdown
> 6. Try deleting and updating tasks in batches of 1
> 
> ## Why make this change
> These changes improve the user experience by making it easier to distinguish between different task priorities and statuses at a glance. They also make it more convenient to update task labels and priorities, and allow for more flexibility in batch task operations.
</details>