### PR TITLE
neon database seeding and reset feature

### DIFF
--- a/packages/neon/package.json
+++ b/packages/neon/package.json
@@ -9,7 +9,9 @@
     "migrate": "tsx src/migrate.ts",
     "with-env": "dotenv -e .env --",
     "dev": "pnpm with-env drizzle-kit studio --port 5556",
-    "seed": "tsx src/seed.ts"
+    "seed": "tsx src/seed.ts",
+    "reset": "tsx src/reset.ts",
+    "db:prepare": "pnpm reset & pnpm migrate & pnpm seed"
   },
   "dependencies": {
     "@neondatabase/serverless": "^0.6.0",

--- a/packages/neon/src/reset.ts
+++ b/packages/neon/src/reset.ts
@@ -1,0 +1,30 @@
+import "dotenv/config";
+
+import { drizzle } from "drizzle-orm/neon-http";
+import { neon } from "@neondatabase/serverless";
+import { sql } from "drizzle-orm";
+import { env } from "../env.mjs";
+
+const { log, error } = console;
+
+const client = neon(env.DATABASE_URL);
+const db = drizzle(client);
+
+async function main(): Promise<void> {
+  try {
+    log("RESETING started...");
+
+    await db.execute(sql`DROP TABLE IF EXISTS users CASCADE;`);
+    await db.execute(sql`DROP TABLE IF EXISTS tasks CASCADE;`);
+    await db.execute(sql`DROP TABLE IF EXISTS session CASCADE;`);
+
+    log("RESETING Successful...");
+    log("RESETING Ended...");
+  } catch (err) {
+    error("Error performing reset operation: ", err);
+  } finally {
+    process.exit(0);
+  }
+}
+
+void main();

--- a/packages/neon/src/seed.ts
+++ b/packages/neon/src/seed.ts
@@ -2,21 +2,45 @@ import "dotenv/config";
 
 import { drizzle } from "drizzle-orm/neon-http";
 import { neon } from "@neondatabase/serverless";
+import { faker } from "@faker-js/faker";
 import { env } from "../env.mjs";
-import { users } from "./schema";
+import { type User, users, tasks } from "./schema";
 
 const { log, error } = console;
 
 const db = drizzle(neon(env.DATABASE_URL));
 
-async function main(): Promise<void> {
-  try {
-    log("SEEDING started...");
-    await db.insert(users).values({
+async function generateDefaultUser(): Promise<User> {
+  const [user] = await db
+    .insert(users)
+    .values({
       tenantId: "user_2WrcO7DqoNUE4HxLdZTkYRyRrqp",
       firstName: "Michael",
       lastName: "Obasi",
       email: "kasmickleva@gmail.com",
+    })
+    .returning();
+  return user as User;
+}
+
+async function main(): Promise<void> {
+  try {
+    log("SEEDING started...");
+    const user = await generateDefaultUser();
+    await db.insert(tasks).values({
+      title: faker.lorem.sentence({ min: 3, max: 5 }),
+      label: "bug",
+      status: "todo",
+      priority: "high",
+      authorId: user.tenantId,
+    });
+
+    await db.insert(tasks).values({
+      title: faker.lorem.sentence({ min: 3, max: 5 }),
+      label: "feature",
+      status: "backlog",
+      priority: "medium",
+      authorId: user.tenantId,
     });
     log("SEEDING Successful...");
     log("SEEDING Ended...");


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces new scripts for resetting and preparing the database. It also enhances the seeding script to generate more realistic data.
> 
> ## What changed
> - Added a new script `reset` to drop existing tables in the database.
> - Added a new script `db:prepare` to reset, migrate, and seed the database in one command.
> - Enhanced the seeding script to generate more realistic task data using the faker library.
> 
> ```diff
> +    "reset": "tsx src/reset.ts",
> +    "db:prepare": "pnpm reset & pnpm migrate & pnpm seed"
> ```
> 
> ```diff
> +import { faker } from "@faker-js/faker";
> +import { type User, users, tasks } from "./schema";
> ```
> 
> ## How to test
> - Run `pnpm db:prepare` to reset, migrate, and seed the database.
> - Check the database to ensure that the tables are created and seeded correctly.
> 
> ## Why make this change
> - The `reset` script allows developers to easily clear the database, which is useful for testing and development.
> - The `db:prepare` script simplifies the process of preparing the database by running the reset, migrate, and seed commands in one go.
> - The enhanced seeding script generates more realistic task data, which can help in testing and development.
</details>