### PR TITLE
implement api package in web app

### DIFF
--- a/apps/web/src/app/_trpc/client.ts
+++ b/apps/web/src/app/_trpc/client.ts
@@ -1,11 +1,3 @@
-// import { type AppRouter } from "@/server/router";
-
-// import { createTRPCReact } from "@trpc/react-query";
-
-// export const trpc = createTRPCReact<AppRouter>({
-//   abortOnUnmount: true,
-// });
-
 import { type AppRouter } from "@taskaider/api";
 
 import { createTRPCReact } from "@trpc/react-query";

--- a/apps/web/src/app/_trpc/client.ts
+++ b/apps/web/src/app/_trpc/client.ts
@@ -1,7 +1,13 @@
-import { type AppRouter } from "@/server/router";
+// import { type AppRouter } from "@/server/router";
+
+// import { createTRPCReact } from "@trpc/react-query";
+
+// export const trpc = createTRPCReact<AppRouter>({
+//   abortOnUnmount: true,
+// });
+
+import { type AppRouter } from "@taskaider/api";
 
 import { createTRPCReact } from "@trpc/react-query";
 
-export const trpc = createTRPCReact<AppRouter>({
-  abortOnUnmount: true,
-});
+export const trpc = createTRPCReact<AppRouter>({ abortOnUnmount: true });

--- a/apps/web/src/app/api/edgestore/[...edgestore]/route.ts
+++ b/apps/web/src/app/api/edgestore/[...edgestore]/route.ts
@@ -1,25 +1,3 @@
-import { createEdgeStoreNextHandler } from "@edgestore/server/adapters/next/app";
-import { initEdgeStore } from "@edgestore/server";
-import { z } from "zod";
-
-const es = initEdgeStore.create();
-
-const edgeStoreRouter = es.router({
-  publicImages: es
-    .imageBucket({ maxSize: 1024 * 1024 * 10, accept: ["image/*"] })
-    .input(z.object({ type: z.enum(["post", "profile"]) }))
-    .path(({ input }) => [{ type: input.type }]),
-
-  protectedFiles: es
-    .fileBucket({ maxSize: 1024 * 1024 * 10 })
-    .input(z.object({ type: z.enum(["post", "profile"]) }))
-    .path(({ input }) => [{ type: input.type }]),
-});
-
-const handler = createEdgeStoreNextHandler({
-  router: edgeStoreRouter,
-});
+import { EdgeStoreHandler as handler } from "@taskaider/api";
 
 export { handler as GET, handler as POST };
-
-export type EdgeStoreRouter = typeof edgeStoreRouter;

--- a/apps/web/src/app/api/trpc/[trpc]/route.ts
+++ b/apps/web/src/app/api/trpc/[trpc]/route.ts
@@ -1,6 +1,5 @@
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
-import { createContext } from "@/server/context";
-import { appRouter } from "@/server/router";
+import { appRouter, createContext } from "@taskaider/api";
 
 export const runtime = "edge";
 

--- a/apps/web/src/app/api/webhook/clerk/route.ts
+++ b/apps/web/src/app/api/webhook/clerk/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { WebhookEvent } from "@clerk/nextjs/server";
-import { serverClient } from "@/server";
+import { serverClient } from "@taskaider/api";
 import { headers } from "next/headers";
 import { Webhook } from "svix";
 import { env } from "@/env";

--- a/apps/web/src/app/dashboard/tasks/@modal/(.)delete/page.tsx
+++ b/apps/web/src/app/dashboard/tasks/@modal/(.)delete/page.tsx
@@ -8,11 +8,9 @@ export default function ({ searchParams }) {
   const { id } = searchParams;
   const { back } = useRouter();
 
-  const onCompleted = () => back();
+  if (!id) return <RedirectToTasks />;
 
-  return id ? (
-    <DeleteTasks taskIds={[id]} mode={Mode.single} onCompleted={onCompleted} />
-  ) : (
-    <RedirectToTasks />
+  return (
+    <DeleteTasks ids={[id]} mode={Mode.single} onCompleted={() => back()} />
   );
 }

--- a/apps/web/src/app/dashboard/tasks/@modal/_modal.tsx
+++ b/apps/web/src/app/dashboard/tasks/@modal/_modal.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { AddTaskSchemaType, Label, PriorityEnum, StatusEnum } from "@/types";
 import { AddNewTask } from "@/app/dashboard/tasks/components/AddNewTask";
 import { DialogContent, DialogHeader, DialogTitle, Dialog } from "ui";
 import { useRouter, useSearchParams } from "next/navigation";
+import { Label, PriorityEnum, StatusEnum } from "@/types";
+import { AddTaskInputType } from "@taskaider/api";
 
 export const Modal = ({ title }) => {
   const searchParams = useSearchParams();
@@ -25,7 +26,7 @@ export const Modal = ({ title }) => {
               priority: searchParams.get("priority") || PriorityEnum.medium,
               status: searchParams.get("status") || StatusEnum.backlog,
               label: searchParams.get("label") || Label.feature,
-            } as AddTaskSchemaType
+            } as AddTaskInputType
           }
           handleClose={handleClose}
           id={searchParams.get("id") || ""}

--- a/apps/web/src/app/dashboard/tasks/components/Column.tsx
+++ b/apps/web/src/app/dashboard/tasks/components/Column.tsx
@@ -36,8 +36,8 @@ export const columns: ColumnDef<Task>[] = [
       <DataTableColumnHeader column={column} title="Task" />
     ),
     cell: ({ row }) => {
-      const value = row.getValue("id") as string;
-      return <div className="w-[80px]">{value.slice(0, 10)}</div>;
+      const value = row.getValue("id") as number;
+      return <div className="w-[80px]">{value}</div>;
     },
     enableSorting: false,
     enableHiding: false,

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -1,6 +1,6 @@
-import { AddTaskSchemaType } from "@/types";
+import { AddTaskInputType } from "@taskaider/api";
 
-export const addTaskDefaultValues: AddTaskSchemaType = {
+export const addTaskDefaultValues: AddTaskInputType = {
   title: "",
   priority: "medium",
   label: "feature",

--- a/apps/web/src/lib/edgestore.ts
+++ b/apps/web/src/lib/edgestore.ts
@@ -1,7 +1,7 @@
 "use client";
 
-import { type EdgeStoreRouter } from "@/app/api/edgestore/[...edgestore]/route";
 import { createEdgeStoreProvider } from "@edgestore/react";
+import { type EdgeStoreRouter } from "@taskaider/api";
 
 const { EdgeStoreProvider, useEdgeStore } =
   createEdgeStoreProvider<EdgeStoreRouter>();

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -1,7 +1,3 @@
-import { addTaskFormSchema } from "@/lib/typeSchema";
-import { z } from "zod";
-
-export type AddTaskSchemaType = z.infer<typeof addTaskFormSchema>;
 export enum PriorityEnum {
   low = "low",
   medium = "medium",

--- a/packages/api/src/lib/edgestore.ts
+++ b/packages/api/src/lib/edgestore.ts
@@ -1,0 +1,23 @@
+import { createEdgeStoreNextHandler } from "@edgestore/server/adapters/next/app";
+import { initEdgeStore } from "@edgestore/server";
+import { z } from "zod";
+
+const es = initEdgeStore.create();
+
+const edgeStoreRouter = es.router({
+  publicImages: es
+    .imageBucket({ maxSize: 1024 * 1024 * 10, accept: ["image/*"] })
+    .input(z.object({ type: z.enum(["post", "profile"]) }))
+    .path(({ input }) => [{ type: input.type }]),
+
+  protectedFiles: es
+    .fileBucket({ maxSize: 1024 * 1024 * 10 })
+    .input(z.object({ type: z.enum(["post", "profile"]) }))
+    .path(({ input }) => [{ type: input.type }]),
+});
+
+export const EdgeStoreHandler = createEdgeStoreNextHandler({
+  router: edgeStoreRouter,
+});
+
+export type EdgeStoreRouter = typeof edgeStoreRouter;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5918,7 +5918,7 @@ packages:
       drizzle-orm: '>=0.23.13'
       zod: '*'
     dependencies:
-      drizzle-orm: 0.28.6(@libsql/client@0.3.6)
+      drizzle-orm: 0.28.6(@neondatabase/serverless@0.6.0)(pg@8.11.3)(postgres@3.4.3)
       zod: 3.22.4
     dev: false
 


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request updates the import statements in several files to use the new package `@taskaider/api` instead of the old package names. It also adds a new file `packages/api/src/lib/edgestore.ts` that contains the implementation for the EdgeStoreHandler and EdgeStoreRouter.
> 
> ## What changed
> - Updated import statements in `apps/web/src/app/_trpc/client.ts`, `apps/web/src/app/api/edgestore/[...edgestore]/route.ts`, `apps/web/src/app/api/trpc/[trpc]/route.ts`, `apps/web/src/app/api/webhook/clerk/route.ts`, `apps/web/src/app/dashboard/tasks/@modal/(.)delete/page.tsx`, `apps/web/src/app/dashboard/tasks/@modal/_modal.tsx`, `apps/web/src/app/dashboard/tasks/components/Column.tsx`, `apps/web/src/lib/constants.ts`, `apps/web/src/lib/edgestore.ts`, `apps/web/src/types/index.ts`, and `packages/api/src/lib/edgestore.ts` to use the new package `@taskaider/api`.
> - Added a new file `packages/api/src/lib/edgestore.ts` that contains the implementation for the EdgeStoreHandler and EdgeStoreRouter.
> 
> ## How to test
> 1. Update the import statements in the mentioned files to use `@taskaider/api` instead of the old package names.
> 2. Verify that the application builds successfully without any errors or warnings.
> 3. Test the functionality of the application to ensure that it works as expected.
> 
> ## Why make this change
> - The old package names were deprecated and replaced with the new package `@taskaider/api`.
> - Updating the import statements to use the new package ensures that the application uses the latest version of the package and avoids any potential compatibility issues.
> - Adding the new file `packages/api/src/lib/edgestore.ts` provides the implementation for the EdgeStoreHandler and EdgeStoreRouter, which are required for the application's functionality.
</details>